### PR TITLE
dplyr 1.0.8, use `if_all()` instead of `across()`

### DIFF
--- a/R/location.R
+++ b/R/location.R
@@ -71,7 +71,7 @@ mark_location <- function(x,
 
   # Check for participants with no location information
   no_location <-
-    dplyr::filter(x, is.na(dplyr::across(tidyselect::all_of(location_col))))
+    dplyr::filter(x, dplyr::if_all(tidyselect::all_of(location_col), is.na))
   n_no_location <- nrow(no_location)
   no_nas <- tidyr::drop_na(x, tidyselect::all_of(location_col))
 


### PR DESCRIPTION
We're in the process of releasing dplyr 1.0.8 and as part of our revdep checks, we've identified a problem with this package. 


````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking examples ... ERROR
  Running examples in ‘excluder-Ex.R’ failed
  The error most likely occurred in:
  
  > ### Name: check_location
  > ### Title: Check for locations outside of the US
  > ### Aliases: check_location
  > 
  > ### ** Examples
  > 
  > # Check for locations outside of the US
  > data(qualtrics_text)
  > check_location(qualtrics_text)
  Error in `dplyr::filter()`: Problem while computing `..1 = is.na(dplyr::across(tidyselect::all_of(location_col)))`.
  ✖ Input `..1` must be a logical vector, not a logical[,2].
  Backtrace:
       ▆
    1. ├─excluder::check_location(qualtrics_text)
    2. │ ├─... %>% keep_marked_column(.data$exclusion_location, keep)
    3. │ └─excluder::mark_location(...)
    4. │   ├─dplyr::filter(x, is.na(dplyr::across(tidyselect::all_of(location_col))))
    5. │   └─dplyr:::filter.data.frame(x, is.na(dplyr::across(tidyselect::all_of(location_col))))
    6. │     └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
    7. │       └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
    8. │         ├─base::withCallingHandlers(...)
    9. │         └─mask$eval_all_filter(dots, env_filter)
   10. ├─excluder:::keep_marked_column(., .data$exclusion_location, keep)
   11. │ └─x %>% ...
   12. ├─dplyr::select(...)
   13. ├─dplyr::filter(., .data$exclusion_location == "location")
   14. ├─dplyr:::dplyr_internal_error(...)
   15. │ └─rlang::abort(class = c(class, "dplyr:::internal_error"), dplyr_error_data = data)
   16. │   └─rlang:::signal_abort(cnd, .file)
   17. │     └─base::signalCondition(cnd)
   18. └─dplyr `<fn>`(`<dpl:::__>`)
  Execution halted

> checking tests ... ERROR
  See below...

── Test failures ─────────────────────────────────────────────────────────────────────────────── testthat ────

> library(testthat)
> library(excluder)
> 
> test_check("excluder")
══ Skipped tests ═══════════════════════════════════════════════════════════════
• On CRAN (15)

══ Failed tests ════════════════════════════════════════════════════════════════
── Error (test-location.R:4:3): Mark output class is same as input class ───────
Error in `dplyr::filter(x, is.na(dplyr::across(tidyselect::all_of(location_col))))`: Problem while computing `..1 = is.na(dplyr::across(tidyselect::all_of(location_col)))`.
x Input `..1` must be a logical vector, not a logical[,2].
Backtrace:

.... (more of the same issue)

````

This pull request fixes it by using `if_all()`.

Please note that even though previous version of `dplyr` let it pass, it probably did not return the right result. 


